### PR TITLE
Add support for sandboxed compiles

### DIFF
--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -468,6 +468,43 @@ switch (process.env.OVERLEAF_FILESTORE_BACKEND) {
     }
 }
 
+
+
+// Overleaf CEP Compiler options to enable sandboxed compiles.
+// --------
+if (process.env.SANDBOXED_COMPILES === 'true') {
+  settings.clsi = {
+    dockerRunner: true,
+    docker: {
+      image: process.env.TEX_LIVE_DOCKER_IMAGE,
+      env: {
+        HOME: '/tmp',
+        PATH:
+          process.env.COMPILER_PATH ||
+          '/usr/local/texlive/2015/bin/x86_64-linux:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      },
+      user: 'www-data',
+    },
+  }
+
+  if (settings.path == null) {
+    settings.path = {}
+  }
+  settings.path.synctexBaseDir = () => '/compile'
+  if (process.env.SANDBOXED_COMPILES_SIBLING_CONTAINERS === 'true') {
+    console.log('Using sibling containers for sandboxed compiles')
+    if (process.env.SANDBOXED_COMPILES_HOST_DIR) {
+      settings.path.sandboxedCompilesHostDir =
+        process.env.SANDBOXED_COMPILES_HOST_DIR
+    } else {
+      console.error(
+        'Sibling containers, but SANDBOXED_COMPILES_HOST_DIR not set'
+      )
+    }
+  }
+}
+
+
 // With lots of incoming and outgoing HTTP connections to different services,
 // sometimes long running, it is a good idea to increase the default number
 // of sockets that Node will hold open.

--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -473,19 +473,21 @@ switch (process.env.OVERLEAF_FILESTORE_BACKEND) {
 // Overleaf CEP Compiler options to enable sandboxed compiles.
 // --------
 if (process.env.SANDBOXED_COMPILES === 'true') {
-  settings.clsi = {
-    dockerRunner: true,
-    docker: {
-      image: process.env.TEX_LIVE_DOCKER_IMAGE,
-      env: {
-        HOME: '/tmp',
-        PATH:
-          process.env.COMPILER_PATH ||
-          '/usr/local/texlive/2015/bin/x86_64-linux:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      },
-      user: 'www-data',
-    },
+  if (!settings.clsi) {
+    settings.clsi = {}; 
   }
+
+  settings.clsi.dockerRunner = true;
+  settings.clsi.docker = {
+    image: process.env.TEX_LIVE_DOCKER_IMAGE,
+    env: { 
+      HOME: '/tmp',
+      PATH:
+        process.env.COMPILER_PATH ||
+        '/usr/local/texlive/2015/bin/x86_64-linux:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    },
+    user: 'www-data',
+  };
 
   if (settings.path == null) {
     settings.path = {}


### PR DESCRIPTION
This pull request adds support for sandboxed compiles. The functionality is already present in Overleaf CE, but was merely disabled because certain flags were omitted from the Overleaf settings. By adding back those flags, sandboxed compiles can be enabled through configuration options.

Snippet was taken directly from a historical version of `server-ce/settings.js` ([here](https://github.com/overleaf/overleaf/blob/efd16d99d6136c1d06164b5897d73e07006103f8/server-ce/settings.js#L602-L629)) with one modification: 
 * The original file completely overwrites the `settings.clsi` object when sibling containers are enabled, but it was already defined on [line 43](https://github.com/overleaf/overleaf/blob/efd16d99d6136c1d06164b5897d73e07006103f8/server-ce/settings.js#L43) where a property `optimiseInDocker` was added. I don't know if it was intentional to overwrite this object, but I decided to keep the property when sibling containers are enabled.