### PR TITLE
Add ENV variables to control SAML signature validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,14 @@ If no matching record is found, the database is searched for a user with the pri
     * Optionally set the signature algorithm for signing requests,
           valid values are 'sha1' (default), 'sha256' (prefered), 'sha512' (most secure, check if your IdP supports it).
 
+- `OVERLEAF_SAML_WANT_ASSERTIONS_SIGNED`
+    * Optionally disable the requirement for assertion signature validation,
+          Either Assertion signature validation or SAMLResponse validation or both should be true to have secure communication.
+
+- `OVERLEAF_SAML_WANT_AUTHN_RESPONSE_SIGNED`
+    * Optionally disable the requirement for SAMLResponse signature validation,
+          Either Assertion signature validation or SAMLResponse validation or both should be true to have secure communication.
+
 - `OVERLEAF_SAML_ADDITIONAL_PARAMS`
     * JSON dictionary of additional query params to add to all requests.
 

--- a/services/web/modules/authentication/saml/app/src/SAMLModuleManager.mjs
+++ b/services/web/modules/authentication/saml/app/src/SAMLModuleManager.mjs
@@ -47,6 +47,8 @@ const SAMLModuleManager = {
       logoutCallbackUrl: `${Settings.siteUrl.replace(/\/+$/, '')}/saml/logout/callback`,
       additionalLogoutParams: JSON.parse(process.env.OVERLEAF_SAML_ADDITIONAL_LOGOUT_PARAMS || '{}'),
       passReqToCallback: true,
+      wantAssertionsSigned: String(process.env.OVERLEAF_SAML_WANT_ASSERTIONS_SIGNED).toLowerCase() === 'true',
+      wantAuthnResponseSigned: String(process.env.OVERLEAF_SAML_WANT_AUTHN_RESPONSE_SIGNED).toLowerCase() === 'true',
     }
     try {
       passport.use(


### PR DESCRIPTION
## Description
Enable SAML authentication with Idp providers that do not provide both SAMLResponse signing and Assertion Signing


## Related issues / Pull Requests
[<!-- Fixes #xyz, Contributes to #xyz, Related to #xyz-->](https://github.com/yu-i-i/overleaf-cep/issues/19)


## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
