### PR TITLE
I need the --network=host settings for building the container

### DIFF
--- a/server-ce/Makefile
+++ b/server-ce/Makefile
@@ -24,6 +24,7 @@ build-base:
 	  --cache-from $(OVERLEAF_BASE_BRANCH) \
 	  --tag $(OVERLEAF_BASE_TAG) \
 	  --tag $(OVERLEAF_BASE_BRANCH) \
+	  --network=host \
 	  $(MONOREPO_ROOT)
 
 
@@ -39,6 +40,7 @@ build-community:
 	  --file Dockerfile \
 	  --tag $(OVERLEAF_TAG) \
 	  --tag $(OVERLEAF_BRANCH) \
+	  --network=host \
 	  $(MONOREPO_ROOT)
 
 SHELLCHECK_OPTS = \


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->

I want to build the docker container. But apt is not able to contact the world. I need to add --network=host to the Makefile for it too work. 


## Contributor Agreement

- [ ] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
