### PR TITLE
Introduce an environment variable to restrict OIDC JIT user creation to a list of email domains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,13 +960,16 @@ The values of the following two required variables will be provided by the admin
     * The value of this attribute will be used by Overleaf as the external user ID, defaults to `id`.
       Other possible reasonable values are `email` and `username` (corresponding to `preferred_username` OIDC claim).
 
-- `OVERLEAF_OIDC_DISABLE_JIT_ACCOUNT_CREATION`
-    * If set to `true`, disables Just-in-Time (JIT) account creation for OIDC users. Only users with pre-existing accounts can log in.
-      An admin must manually create the user account using the OIDC user’s email address, with either a strong random password or, preferably,
-      without the `hashedPassword` field at all. The OIDC user will be able to log in only after that. Default: `false`.
-
 - `OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS`
-    * If set to a comma-separated list of email address domains, an OIDC user will be created if its email address domain matches one of the list. This does not override `OVERLEAF_OIDC_DISABLE_JIT_ACCOUNT_CREATION` when it is set to `false`.
+    * Restricts Just-in-Time (JIT) account creation for users authenticating via OIDC. If set to a comma-separated list of domain names, a new account
+      will be created only if the domain of the user's email address matches one in the listed domains. If the domain does not match, an admin must
+      manually create the user account using the OIDC user’s email address, with either a strong random password or, preferably, without the `hashedPassword` field at all.
+      Domain names may include a leading `*.` wildcard to match subdomains.
+
+      - Example: To allow JIT account creation for users with email address like `name@example.com` and `name@math.example.com`:  
+        `OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS=example.com, *.example.com`
+      - Example: To completely disable JIT account creation:  
+        `OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS=`
 
 - `OVERLEAF_OIDC_UPDATE_USER_DETAILS_ON_LOGIN`
     * If set to `true`, updates the user `first_name` and `last_name` field on login,

--- a/services/web/app/src/infrastructure/Features.js
+++ b/services/web/app/src/infrastructure/Features.js
@@ -54,7 +54,7 @@ const Features = {
       case 'registration-page':
         return (
           !Features.externalAuthenticationSystemUsed() ||
-          Boolean(Settings.overleaf) || Settings.oidc?.disableJITAccountCreation
+          Boolean(Settings.overleaf) || Settings.oidc?.allowedOIDCEmailDomains
         )
       case 'registration':
         return Boolean(Settings.overleaf)

--- a/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationController.mjs
+++ b/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationController.mjs
@@ -103,7 +103,7 @@ const OIDCAuthenticationController = {
     if (user) {
       return { user, info: undefined }
     } else { // user account is not created
-      logger.debug({ email : profile.emails[0].value }, 'OIDC users JIT account creation is off')
+      logger.debug({ email : profile.emails[0].value }, 'OIDC JIT account creation is not allowed for this email')
       return {
         user: false,
         info: {

--- a/services/web/modules/authentication/oidc/app/src/OIDCModuleManager.mjs
+++ b/services/web/modules/authentication/oidc/app/src/OIDCModuleManager.mjs
@@ -16,9 +16,10 @@ const OIDCModuleManager = {
       attUserId:    process.env.OVERLEAF_OIDC_USER_ID_FIELD || 'id',
       attAdmin:     process.env.OVERLEAF_OIDC_IS_ADMIN_FIELD,
       valAdmin:     process.env.OVERLEAF_OIDC_IS_ADMIN_FIELD_VALUE,
-      allowedOIDCEmailDomains:     process.env.OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS,
       updateUserDetailsOnLogin: boolFromEnv(process.env.OVERLEAF_OIDC_UPDATE_USER_DETAILS_ON_LOGIN),
-      disableJITAccountCreation: boolFromEnv(process.env.OVERLEAF_OIDC_DISABLE_JIT_ACCOUNT_CREATION),
+      allowedOIDCEmailDomains: process.env.OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS === undefined
+        ? null
+        : process.env.OVERLEAF_OIDC_ALLOWED_EMAIL_DOMAINS.split(',').map(s => s.trim()).filter(Boolean),
     }
   },
   passportSetup(passport, callback) {


### PR DESCRIPTION
## Description
In my particular instance, it is useful to allow only Google accounts whose email domains match my university's. Therefore, I've implemented this variable to make it easier for one to restrict OIDC user creation. 

## Contributor Agreement

- [X] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
