### PR TITLE
feat(auth): add env vars to control login methods in navbar

### DIFF
--- a/services/web/app/src/infrastructure/ExpressLocals.js
+++ b/services/web/app/src/infrastructure/ExpressLocals.js
@@ -231,6 +231,17 @@ module.exports = function (webRouter, privateApiRouter, publicApiRouter) {
       return staticFilesBase + path
     }
 
+    res.locals.local_login_enabled =
+      (process.env.OVERLEAF_ENABLE_LOCAL_LOGIN || 'true') === 'true'
+    res.locals.saml_login_button_text =
+      process.env.OVERLEAF_SAML_LOGIN_BUTTON || 'Log in with SAML'
+    res.locals.saml_login_in_navbar =
+      process.env.OVERLEAF_SAML_LOGIN_IN_NAVBAR === 'true'
+    res.locals.oidc_login_button_text =
+      process.env.OVERLEAF_OIDC_LOGIN_BUTTON || 'Log in with OIDC'
+    res.locals.oidc_login_in_navbar =
+      process.env.OVERLEAF_OIDC_LOGIN_IN_NAVBAR === 'true'
+
     next()
   })
 

--- a/services/web/app/views/layout/navbar-marketing-bootstrap-5.pug
+++ b/services/web/app/views/layout/navbar-marketing-bootstrap-5.pug
@@ -191,7 +191,7 @@ nav.navbar.navbar-default.navbar-main.navbar-expand-lg(
 						if (settings.saml && settings.saml.enable) && (saml_login_in_navbar || !local_login_enabled)
 							+nav-item.primary
 								+nav-link(
-									href='/oidc/login'
+									href='/saml/login'
 									event-tracking='menu-click'
 									event-tracking-action='clicked'
 									event-tracking-trigger='click'

--- a/services/web/app/views/layout/navbar-marketing-bootstrap-5.pug
+++ b/services/web/app/views/layout/navbar-marketing-bootstrap-5.pug
@@ -151,16 +151,17 @@ nav.navbar.navbar-default.navbar-main.navbar-expand-lg(
 					// logged out
 					if !getSessionUser()
 						// register link
-						if hasFeature('registration-page')
-							+nav-item.primary
-								+nav-link(
-									href='/register'
-									event-tracking='menu-click'
-									event-tracking-action='clicked'
-									event-tracking-trigger='click'
-									event-tracking-mb='true'
-									event-segmentation={page: currentUrl, item: 'register', location: 'top-menu'}
-								) #{translate('sign_up')}
+						if local_login_enabled
+							if hasFeature('registration-page')
+								+nav-item.primary
+									+nav-link(
+										href='/register'
+										event-tracking='menu-click'
+										event-tracking-action='clicked'
+										event-tracking-trigger='click'
+										event-tracking-mb='true'
+										event-segmentation={page: currentUrl, item: 'register', location: 'top-menu'}
+									) #{translate('sign_up')}
 
 						// templates link
 						if settings.templates
@@ -175,15 +176,40 @@ nav.navbar.navbar-default.navbar-main.navbar-expand-lg(
 								) #{translate('templates')}
 
 						// login link
-						+nav-item
-							+nav-link(
-								href='/login'
-								event-tracking='menu-click'
-								event-tracking-action='clicked'
-								event-tracking-trigger='click'
-								event-tracking-mb='true'
-								event-segmentation={page: currentUrl, item: 'login', location: 'top-menu'}
-							) #{translate('log_in')}
+						if local_login_enabled
+							+nav-item
+								+nav-link(
+									href='/login'
+									event-tracking='menu-click'
+									event-tracking-action='clicked'
+									event-tracking-trigger='click'
+									event-tracking-mb='true'
+									event-segmentation={page: currentUrl, item: 'login', location: 'top-menu'}
+								) #{translate('log_in')}
+
+						// SAML login link
+						if (settings.saml && settings.saml.enable) && (saml_login_in_navbar || !local_login_enabled)
+							+nav-item.primary
+								+nav-link(
+									href='/oidc/login'
+									event-tracking='menu-click'
+									event-tracking-action='clicked'
+									event-tracking-trigger='click'
+									event-tracking-mb='true'
+									event-segmentation={page: currentUrl, item: 'login', location: 'top-menu'}
+								) #{saml_login_button_text}
+
+						// OIDC login link
+						if (settings.oidc && settings.oidc.enable) && (oidc_login_in_navbar || !local_login_enabled)
+							+nav-item.primary
+								+nav-link(
+									href='/oidc/login'
+									event-tracking='menu-click'
+									event-tracking-action='clicked'
+									event-tracking-trigger='click'
+									event-tracking-mb='true'
+									event-segmentation={page: currentUrl, item: 'login', location: 'top-menu'}
+								) #{oidc_login_button_text}
 
 					// projects link and account menu
 					if getSessionUser()

--- a/services/web/app/views/user/login.pug
+++ b/services/web/app/views/user/login.pug
@@ -12,38 +12,39 @@ block content
 									h1 !{login_support_title}
 								else
 									h1 #{translate("log_in")} 
-							form(name='loginForm' data-ol-async-form action='/login' method='POST')
-								input(name='_csrf' type='hidden' value=csrfToken)
-								+formMessagesNewStyle
-								+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
-									| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
-									span.visually-hidden(id='resetPasswordDescription')
-										| #{translate('reset_password_link')}
-								+customFormMessageNewStyle('password-compromised')
-									| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
-								.form-group
-									input.form-control(
-										name='email'
-										type=(settings.ldap && settings.ldap.enable) ? 'text' : 'email'
-										required
-										placeholder=(settings.ldap && settings.ldap.enable) ? settings.ldap.placeholder : 'email@example.com'
-										autofocus='true'
-									)
-								.form-group
-									input.form-control(
-										name='password'
-										type='password'
-										required
-										placeholder='********'
-									)
-								.actions
-									button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
-										span(data-ol-inflight='idle') #{translate("login")}
-										span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
-									a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
-								if login_support_text
-									hr
-									p.text-center !{login_support_text}
+							if local_login_enabled
+								form(name='loginForm' data-ol-async-form action='/login' method='POST')
+									input(name='_csrf' type='hidden' value=csrfToken)
+									+formMessagesNewStyle
+									+customFormMessageNewStyle('invalid-password-retry-or-reset', 'danger')
+										| !{translate('email_or_password_wrong_try_again_or_reset', {}, [{ name: 'a', attrs: { href: '/user/password/reset', 'aria-describedby': 'resetPasswordDescription' } }])}
+										span.visually-hidden(id='resetPasswordDescription')
+											| #{translate('reset_password_link')}
+									+customFormMessageNewStyle('password-compromised')
+										| !{translate('password_compromised_try_again_or_use_known_device_or_reset', {}, [{name: 'a', attrs: {href: 'https://haveibeenpwned.com/passwords', rel: 'noopener noreferrer', target: '_blank'}}, {name: 'a', attrs: {href: '/user/password/reset', target: '_blank'}}])}.
+									.form-group
+										input.form-control(
+											name='email'
+											type=(settings.ldap && settings.ldap.enable) ? 'text' : 'email'
+											required
+											placeholder=(settings.ldap && settings.ldap.enable) ? settings.ldap.placeholder : 'email@example.com'
+											autofocus='true'
+										)
+									.form-group
+										input.form-control(
+											name='password'
+											type='password'
+											required
+											placeholder='********'
+										)
+									.actions
+										button.btn-primary.btn(type='submit' data-ol-disabled-inflight)
+											span(data-ol-inflight='idle') #{translate("login")}
+											span(hidden data-ol-inflight='pending') #{translate("logging_in")}…
+										a.float-end(href='/user/password/reset') #{translate("forgot_your_password")}?
+									if login_support_text
+										hr
+										p.text-center !{login_support_text}
 							if settings.saml && settings.saml.enable
 								.actions(style='margin-top: 30px;')
 									a.button.btn-secondary.btn(


### PR DESCRIPTION
## Description
<!-- Goal of the pull request -->
Added env vars to disable local auth and add login buttons for SAML and OIDC in navbar.

- OVERLEAF_ENABLE_LOCAL_LOGIN: disable local username/password login when false
- OVERLEAF_SAML_LOGIN_BUTTON: set custom SAML login button text
- OVERLEAF_SAML_LOGIN_IN_NAVBAR: toggle visibility of SAML login button
- OVERLEAF_OIDC_LOGIN_BUTTON: set custom OIDC login button text
- OVERLEAF_OIDC_LOGIN_IN_NAVBAR: toggle visibility of OIDC login button


## Contributor Agreement

- [x] I confirm I have signed the [Contributor License Agreement](https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md#contributor-license-agreement)
