### PR TITLE
Add MAX_ZIP_UPLOAD_SIZE and MAX_ZIP_CONTENT_SIZE to upload bigger zip…

### DIFF
--- a/server-ce/Dockerfile
+++ b/server-ce/Dockerfile
@@ -111,6 +111,19 @@ ENV GRACEFUL_SHUTDOWN_DELAY_SECONDS=1
 ENV NODE_ENV="production"
 ENV LOG_LEVEL="info"
 
+# Set environment variable for max upload zip file
+# ------------------------------------------------
+# Increase the zip content file from 300MB to 2000MB by default with an environment variable MAX_ZIP_CONTENT_SIZE that can be configured.
+ENV MAX_ZIP_CONTENT_SIZE=2000
+RUN sed -i 's/ONE_MEG \* 300/ONE_MEG \* process.env.MAX_ZIP_CONTENT_SIZE/g'  /overleaf/services/web/app/src/Features/Uploads/ArchiveManager.js
+
+# Increase the zip upload file from 50MB to 1024MB by default with an environment variable MAX_ZIP_UPLOAD_SIZE that can be configured.
+ENV MAX_ZIP_UPLOAD_SIZE=1024
+RUN sed -i 's/client_max_body_size 50/client_max_body_size ${MAX_ZIP_UPLOAD_SIZE}/g' /etc/nginx/templates/nginx.conf.template
+RUN sed -i 's/maxUploadSize: 50 \* 1024 \* 1024/maxUploadSize: process.env.MAX_ZIP_UPLOAD_SIZE \* 1024 \* 1024/g' /overleaf/services/web/config/settings.defaults.js
+# For templating the nginx.conf file add the env MAX_ZIP_UPLOAD_SIZE !
+RUN sed -i 's/${NGINX_WORKER_PROCESSES}/${NGINX_WORKER_PROCESSES} ${MAX_ZIP_UPLOAD_SIZE}/g' /etc/my_init.d/*_nginx_config_template.sh
+
 
 EXPOSE 80
 


### PR DESCRIPTION
## Description

Increase the size of zip files you can upload in a project by using 2 new environment variables in the [DockerFile](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/server-ce/Dockerfile):

- `MAX_ZIP_UPLOAD_SIZE` (default: 1024 (MB)) used in the following files:
    - The setting file [`services/web/config/settings.defaults.js`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/services/web/config/settings.defaults.js#L371) replacing the hard-coded 50 MB.
    - The nginx template configuration file [`server-ce/nginx/nginx.conf.template`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/server-ce/nginx/nginx.conf.template#L49) replacing the value of the `client_max_body_size`.
    - The script [ `server-ce/init_scripts/200_nginx_config_template.sh`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/server-ce/init_scripts/200_nginx_config_template.sh#) that changes the variables in the nginx template configuration file by their values.
-  `MAX_ZIP_CONTENT_SIZE` (default: 2000 (MB)) replacing, in the file [`services/web/app/src/Features/Uploads/ArchiveManager.js`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/services/web/app/src/Features/Uploads/ArchiveManager.js#L72) , the default value of 300 MB for the maximum size of the zip file content.

**Please note the modifications of the previous files are directly done in the Dockerfile when building the image!**


## Related issues / Pull Requests

When you need to import large projects (e.g. reports, theses, ...) into Overleaf, 50 MB is, usually, not enough. Project files must be split into multiple zip files and imported one by one. This PR sovles this issue.


## Limitations

You need (at least) 4GB ram for Overleaf in order to make it work correctly with the new default environment variables.
