### PR TITLE
Add MAX_UPLOAD_SIZE environment variable

### DIFF
--- a/server-ce/init_scripts/200_nginx_config_template.sh
+++ b/server-ce/init_scripts/200_nginx_config_template.sh
@@ -20,6 +20,7 @@ if [ -f "${nginx_template_file}" ]; then
   export NGINX_KEEPALIVE_TIMEOUT="${NGINX_KEEPALIVE_TIMEOUT:-65}"
   export NGINX_WORKER_CONNECTIONS="${NGINX_WORKER_CONNECTIONS:-768}"
   export NGINX_WORKER_PROCESSES="${NGINX_WORKER_PROCESSES:-4}"
+  export MAX_UPLOAD_SIZE="${MAX_UPLOAD_SIZE:-50}"
 
   echo "Nginx: generating config file from template"
 
@@ -31,6 +32,7 @@ if [ -f "${nginx_template_file}" ]; then
     ${NGINX_KEEPALIVE_TIMEOUT}
     ${NGINX_WORKER_CONNECTIONS}
     ${NGINX_WORKER_PROCESSES}
+    ${MAX_UPLOAD_SIZE}
   ' \
     < "${nginx_template_file}" \
     > "${nginx_config_file}"

--- a/server-ce/nginx/nginx.conf.template
+++ b/server-ce/nginx/nginx.conf.template
@@ -46,7 +46,7 @@ http {
 	gzip_disable "msie6";
 	gzip_proxied any; # allow upstream server to compress.
 
-	client_max_body_size 50m;
+	client_max_body_size ${MAX_UPLOAD_SIZE}m;
 
 	# gzip_vary on;
 	# gzip_proxied any;

--- a/services/web/app/src/Features/Uploads/ArchiveManager.js
+++ b/services/web/app/src/Features/Uploads/ArchiveManager.js
@@ -69,7 +69,7 @@ const ArchiveManager = {
             new InvalidZipFileError({ info: { totalSizeInBytes } })
           )
         }
-        const isTooLarge = totalSizeInBytes > ONE_MEG * 300
+        const isTooLarge = totalSizeInBytes > ONE_MEG * 6 * Settings.maxUploadSize //6 * 50 MB = 300 MB
         return callback(null, isTooLarge)
       })
     })

--- a/services/web/config/settings.defaults.js
+++ b/services/web/config/settings.defaults.js
@@ -368,7 +368,9 @@ module.exports = {
     process.env.PROJECT_UPLOAD_TIMEOUT || '120000',
     10
   ),
-  maxUploadSize: 50 * 1024 * 1024, // 50 MB
+  maxUploadSize: process.env.MAX_UPLOAD_SIZE
+    ? parseInt(process.env.MAX_UPLOAD_SIZE, 10) * 1024 * 1024
+    :  50 * 1024 * 1024, // 50 MB
   multerOptions: {
     preservePath: process.env.MULTER_PRESERVE_PATH,
   },


### PR DESCRIPTION
## Description

Increase the size of zip files you can upload in a project by using a new environment variable `MAX_UPLOAD_SIZE` (default: 50 (MB) if not specified) in the following files:

- The setting file [`/services/web/config/settings.defaults.js`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/services/web/config/settings.defaults.js#L371) replacing the hard-coded 50 MB maximum upload size (or zip files.
- The file [`/services/web/app/src/Features/Uploads/ArchiveManager.js`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/services/web/app/src/Features/Uploads/ArchiveManager.js#L72) where the default value of 300 MB for the maximum size of the zip file content is replaced by 6 times `MAX_UPLOAD_SIZE`.
- The nginx template configuration file [`server-ce/nginx/nginx.conf.template`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/server-ce/nginx/nginx.conf.template#L49) replacing the value of the `client_max_body_size`.
- The script [ `server-ce/init_scripts/200_nginx_config_template.sh`](https://github.com/yu-i-i/overleaf-cep/blob/ext-ce/server-ce/init_scripts/200_nginx_config_template.sh#) that changes the variables in the nginx template configuration file by their values.


## Related issues / Pull Requests

When you need to import large projects (e.g. reports, theses, ...) into Overleaf, 50 MB is, usually, not enough. Project files must be split into multiple zip files and imported one by one. This PR solves this issue by adding a new environment variable that can be added in the [`variables.env` of the overleaf toolkit](https://github.com/overleaf/toolkit).

