### PR TITLE
fix: generate overleaf.conf dynamically to support GIT_BRIDGE_HOST and GIT_BRIDGE_PORT

### DIFF
--- a/server-ce/Dockerfile
+++ b/server-ce/Dockerfile
@@ -39,7 +39,7 @@ ADD server-ce/config/env.sh /etc/overleaf/env.sh
 # Configure nginx
 # ---------------
 ADD server-ce/nginx/nginx.conf.template /etc/nginx/templates/nginx.conf.template
-ADD server-ce/nginx/overleaf.conf /etc/nginx/sites-enabled/overleaf.conf
+ADD server-ce/nginx/overleaf.conf.template /etc/nginx/templates/overleaf.conf.template
 ADD server-ce/nginx/clsi-nginx.conf /etc/nginx/sites-enabled/clsi-nginx.conf
 
 
@@ -111,7 +111,9 @@ ENV GRACEFUL_SHUTDOWN_DELAY_SECONDS=1
 ENV NODE_ENV="production"
 ENV LOG_LEVEL="info"
 
-
+ENV GIT_BRIDGE_HOST=git-bridge
+ENV GIT_BRIDGE_PORT=8000
+ENV GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE=52428800
 EXPOSE 80
 
 ENTRYPOINT ["/sbin/my_init"]

--- a/server-ce/init_scripts/200_nginx_config_template.sh
+++ b/server-ce/init_scripts/200_nginx_config_template.sh
@@ -16,12 +16,18 @@ fi
 nginx_template_file="${nginx_templates_dir}/nginx.conf.template"
 nginx_config_file="${nginx_dir}/nginx.conf"
 
+overleaf_template_file="${nginx_templates_dir}/overleaf.conf.template"
+overleaf_config_file="${nginx_dir}/sites-enabled/overleaf.conf"
+
 if [ -f "${nginx_template_file}" ]; then
   export NGINX_KEEPALIVE_TIMEOUT="${NGINX_KEEPALIVE_TIMEOUT:-65}"
   export NGINX_WORKER_CONNECTIONS="${NGINX_WORKER_CONNECTIONS:-768}"
   export NGINX_WORKER_PROCESSES="${NGINX_WORKER_PROCESSES:-4}"
   export MAX_UPLOAD_SIZE="${MAX_UPLOAD_SIZE:-50}"
 
+  export GIT_BRIDGE_HOST="${GIT_BRIDGE_HOST:-git-bridge}"
+  export GIT_BRIDGE_PORT="${GIT_BRIDGE_PORT:-8000}"
+  export GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE="${GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE:-52428800}"
   echo "Nginx: generating config file from template"
 
   # Note the single-quotes, they are important.
@@ -36,6 +42,15 @@ if [ -f "${nginx_template_file}" ]; then
   ' \
     < "${nginx_template_file}" \
     > "${nginx_config_file}"
+
+  # Config git-bridge in nginx
+  envsubst '
+    ${GIT_BRIDGE_HOST}
+    ${GIT_BRIDGE_PORT}
+    ${GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE}
+  ' \
+    < "${overleaf_template_file}" \
+    > "${overleaf_config_file}"
 
   echo "Checking Nginx config"
   nginx -t

--- a/server-ce/nginx/overleaf.conf.template
+++ b/server-ce/nginx/overleaf.conf.template
@@ -24,8 +24,9 @@ server {
 	location ^~ /git/ {
 		resolver_timeout 2s;
 		resolver 127.0.0.11 valid=10s;
-		set $git_upstream http://git-bridge:8000;
+		set $git_upstream http://${GIT_BRIDGE_HOST}:${GIT_BRIDGE_PORT};
 		rewrite ^/git/(.*)$ /$1 break;
+		client_max_body_size ${GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE};
 		proxy_pass $git_upstream;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
## Background
The Nginx /git/ upstream was not flexible enough across environments, making it hard to adjust Git Bridge host/port without changing static config.

## What Changed
1. Switched Overleaf vhost config from a static file to a template rendered at container startup.
2. Added environment-variable support for Git Bridge routing:
  * `GIT_BRIDGE_HOST` (default: git-bridge)
  * `GIT_BRIDGE_PORT` (image default: 8000)
3. Updated /git/ proxy upstream in the template to use:
  * `http://${GIT_BRIDGE_HOST}:${GIT_BRIDGE_PORT}`
