### PR TITLE
Fix: set analyticsId when admin creates a new user

### DIFF
--- a/services/web/modules/admin-tools/app/src/UserListController.mjs
+++ b/services/web/modules/admin-tools/app/src/UserListController.mjs
@@ -116,6 +116,7 @@ async function registerNewUser(req, res, next) {
   }
   delete req.body.isExternal
   req.body.password = crypto.randomBytes(32).toString('hex')
+  req.body.analyticsId = crypto.randomUUID()
 
  let user
   try {


### PR DESCRIPTION
The admin-tools module calls UserRegistrationHandler.registerNewUser() passing req.body directly, but analyticsId is not included, causing UserCreator.createNewUser() to throw 'bug: attributes.analyticsId is missing' when an admin creates a user via the admin panel.

## Cause

`UserListController.registerNewUser` calls `UserRegistrationHandler.promises.registerNewUser(req.body)` passing the request body directly. The standard self-registration flow generates `analyticsId` itself (via `crypto.randomUUID()`) before calling the same handler, but the admin-tools flow does not, so `UserCreator.createNewUser` rejects the call as soon as it checks for `attributes.analyticsId`.

## Fix

Generate `analyticsId` in `UserListController.registerNewUser` before calling `registerNewUser`, mirroring what the standard registration flow already does.

## How to reproduce

1. Deploy `ext-ce` with sandboxed compiles / admin-tools enabled.
2. Log in as admin, go to `/admin/user`.
3. Click "Create user", fill in an email, submit.
4. Observe the 500 error and the stack trace above in `web.log`.

With this patch applied, user creation succeeds, and the subsequent activation email is sent correctly.

## Testing

Tested locally on a Toolkit-based deployment (CEP `ext-ce`, Server CE 6.1.1 base) with sandboxed compiles enabled. Confirmed:
- User creation via `/admin/user/create` no longer throws.
- `analyticsId` is correctly persisted on the new user document.
- Activation email is sent without further errors.