### PR TITLE
Fix: zip archive MAX_UNCOMPRESSED_BYTES = 6 * MAX_UPLOAD_SIZE

### DIFF
--- a/services/web/app/src/Features/Uploads/ArchiveManager.mjs
+++ b/services/web/app/src/Features/Uploads/ArchiveManager.mjs
@@ -15,7 +15,7 @@ import {
 } from './ArchiveErrors.mjs'
 import FileTypeManager from './FileTypeManager.mjs'
 
-const MAX_UNCOMPRESSED_BYTES = 1024 * 1024 * 300 // 300MB
+const MAX_UNCOMPRESSED_BYTES = 6 *  Settings.maxUploadSize // 300MB (by default)
 
 /**
  * Check if a zip entry's file path is safe and return the destination path.


### PR DESCRIPTION
## Description

When the MAX_UPLOAD_SIZE value is changed, large ZIP files cannot be extracted because their extracted size is limited to 300 MB by default.

To resolve this issue, the MAX_UNCOMPRESSED_BYTES value is set to six times the MAX_UPLOAD_SIZE value.