### PR TITLE
OIDC: enable non standard claims in admin check

### DIFF
--- a/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationController.mjs
+++ b/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationController.mjs
@@ -53,7 +53,8 @@ const OIDCAuthenticationController = {
       }
     )(req, res, next)
   },
-  async doPassportLogin(req, issuer, profile, context, idToken, accessToken, refreshToken, done) {
+  async doPassportLogin(req, issuer, uiProfile, idProfile, context, idToken, accessToken, refreshToken, params, done) {
+    const profile = uiProfile ?? idProfile //id Profile if _skipUserProfile is true
     let user, info
     try {
       if(req.session.intent === 'link') {

--- a/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationManager.mjs
+++ b/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationManager.mjs
@@ -23,7 +23,8 @@ const OIDCAuthenticationManager = {
       if (attAdmin === 'email') {
         isAdmin = (email === valAdmin)
       } else {
-        isAdmin = (profile[attAdmin] === valAdmin)
+        const adminClaim = profile[attAdmin] ?? profile._json?.[attAdmin]
+        isAdmin = (adminClaim === valAdmin)
       }
     }
     const oidcUserData = null // Possibly it can be used later

--- a/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationManager.mjs
+++ b/services/web/modules/authentication/oidc/app/src/OIDCAuthenticationManager.mjs
@@ -23,7 +23,7 @@ const OIDCAuthenticationManager = {
       if (attAdmin === 'email') {
         isAdmin = (email === valAdmin)
       } else {
-        const adminClaim = profile[attAdmin] ?? profile._json?.[attAdmin]
+        const adminClaim = profile[attAdmin] || profile._json?.[attAdmin]
         isAdmin = (adminClaim === valAdmin)
       }
     }


### PR DESCRIPTION
## Summary
OIDC authentication fails to assign administrator privileges when using the custom claim environment variables:
- `OVERLEAF_OIDC_IS_ADMIN_FIELD` (maps to `attAdmin`)
- `OVERLEAF_OIDC_IS_ADMIN_FIELD_VALUE` (maps to `valAdmin`)

## Root Cause Analysis

### Issue 1: Evaluation of Custom Claims
The current evaluation `profile[attAdmin] === valAdmin` assumes the claim exists directly on the root `profile` object. 

However, [`passport-openidconnect`](https://github.com/jaredhanson/passport-openidconnect/blob/v0.1.2/lib/profile.js) only maps a fixed set of standard OIDC claims to the top-level `profile` object. Custom claims returned via a UserInfo request are not exposed on `profile` directly—they are stored inside `profile._json`. 

Even when configuring the ID token to include extra claims, `passport-openidconnect` does not parse custom properties onto the `profile` object.

### Issue 2: UserInfo Endpoint Is Skipped
`passport-openidconnect` supports two profile sources:
- `idProfile` (parsed from the ID token)
- `uiProfile` (fetched via the UserInfo endpoint and stored in `profile._json`)

The strategy checks `_skipUserProfile` via function arity ([`strategy.js#L70`](https://github.com/jaredhanson/passport-openidconnect/blob/v0.1.2/lib/strategy.js#L70)). It skips fetching UserInfo unless the `doPassportLogin` verify callback explicitly accepts **10 parameters**. 

Without these 10 arguments, the strategy never queries UserInfo, leaving `profile._json` empty and making custom claims inaccessible.

---

## Proposed Changes
- Updated the `doPassportLogin` verify callback arity to 10 parameters so `passport-openidconnect` enables `uiProfile` fetching.
- Updated claim evaluation to check ` profile[attAdmin] || profile._json?.[attAdmin]`.
- *(Optional not implemented)* Add `OVERLEAF_OIDC_SKIP_USERINFO` (default: `false`) to preserve the current behaviour if a deployment does not require UserInfo fetching.

---

## How to Test
1. Set up an OIDC Provider that emits a custom claim (e.g., `"roles": "admin"` or `"is_overleaf_admin": "true"`).
2. Configure Overleaf with:
   ```env
   OVERLEAF_OIDC_IS_ADMIN_FIELD="roles"
   OVERLEAF_OIDC_IS_ADMIN_FIELD_VALUE="admin"