### PR TITLE
Add separate header logos for light and dark themes

### DIFF
--- a/server-ce/config/settings.js
+++ b/server-ce/config/settings.js
@@ -338,8 +338,20 @@ if (process.env.OVERLEAF_RIGHT_FOOTER != null) {
   }
 }
 
-if (process.env.OVERLEAF_HEADER_IMAGE_URL != null) {
-  settings.nav.custom_logo = process.env.OVERLEAF_HEADER_IMAGE_URL
+const legacyHeaderImageUrl = process.env.OVERLEAF_HEADER_IMAGE_URL
+const lightHeaderImageUrl =
+  process.env.OVERLEAF_HEADER_IMAGE_URL_LIGHT ||
+  legacyHeaderImageUrl ||
+  process.env.OVERLEAF_HEADER_IMAGE_URL_DARK
+const darkHeaderImageUrl =
+  process.env.OVERLEAF_HEADER_IMAGE_URL_DARK ||
+  legacyHeaderImageUrl ||
+  lightHeaderImageUrl
+
+if (lightHeaderImageUrl || darkHeaderImageUrl) {
+  settings.nav.custom_logo = lightHeaderImageUrl || darkHeaderImageUrl
+  settings.nav.custom_logo_light = lightHeaderImageUrl || darkHeaderImageUrl
+  settings.nav.custom_logo_dark = darkHeaderImageUrl || lightHeaderImageUrl
 }
 
 if (process.env.OVERLEAF_HEADER_EXTRAS != null) {

--- a/server-ce/test/customization.spec.ts
+++ b/server-ce/test/customization.spec.ts
@@ -1,5 +1,8 @@
 import { isExcludedBySharding, startWith } from './helpers/config'
 
+const lightLogoUrl = 'https://example.com/logo-light.svg'
+const darkLogoUrl = 'https://example.com/logo-dark.svg'
+
 describe('Customization', function () {
   if (isExcludedBySharding('CE_CUSTOM_1')) return
 
@@ -18,6 +21,8 @@ describe('Customization', function () {
     startWith({
       vars: {
         OVERLEAF_APP_NAME: 'CUSTOM APP NAME',
+        OVERLEAF_HEADER_IMAGE_URL_LIGHT: lightLogoUrl,
+        OVERLEAF_HEADER_IMAGE_URL_DARK: darkLogoUrl,
         OVERLEAF_LEFT_FOOTER: JSON.stringify([{ text: 'CUSTOM LEFT FOOTER' }]),
         OVERLEAF_RIGHT_FOOTER: JSON.stringify([
           { text: 'CUSTOM RIGHT FOOTER' },
@@ -29,6 +34,24 @@ describe('Customization', function () {
       cy.visit('/')
       cy.findByRole('navigation', { name: 'Primary' }).findByText(
         'CUSTOM APP NAME'
+      )
+    })
+
+    it('should switch the custom logo with the theme', function () {
+      cy.visit('/login')
+
+      cy.get('.navbar-logo-custom').should('not.have.attr', 'style')
+      cy.get('.navbar-logo-custom').should(
+        'have.css',
+        'background-image',
+        `url("${lightLogoUrl}")`
+      )
+
+      cy.get('body').invoke('attr', 'data-theme', 'default')
+      cy.get('.navbar-logo-custom').should(
+        'have.css',
+        'background-image',
+        `url("${darkLogoUrl}")`
       )
     })
 

--- a/server-ce/test/host-admin.js
+++ b/server-ce/test/host-admin.js
@@ -190,6 +190,8 @@ const allowedVars = z.object(
   Object.fromEntries(
     [
       'OVERLEAF_APP_NAME',
+      'OVERLEAF_HEADER_IMAGE_URL_LIGHT',
+      'OVERLEAF_HEADER_IMAGE_URL_DARK',
       'OVERLEAF_LEFT_FOOTER',
       'OVERLEAF_RIGHT_FOOTER',
       'OVERLEAF_PROXY_LEARN',

--- a/services/web/app/views/layout-base.pug
+++ b/services/web/app/views/layout-base.pug
@@ -16,6 +16,18 @@ html(
 
 	block vars
 
+	-
+		const headerImageUrlLight =
+			settings.nav.custom_logo_light || settings.nav.custom_logo
+		const headerImageUrlDark =
+			settings.nav.custom_logo_dark ||
+			settings.nav.custom_logo ||
+			headerImageUrlLight
+		const customHeaderLogoStyle = headerImageUrlLight
+			? `--navbar-custom-logo-light-url:url(${JSON.stringify(headerImageUrlLight)});` +
+				`--navbar-custom-logo-dark-url:url(${JSON.stringify(headerImageUrlDark)})`
+			: undefined
+
 	head
 		include ./_metadata.pug
 
@@ -106,6 +118,7 @@ html(
 			'red-nav-bar-for-admins': !settings.isDevEnv && hasFeature('saas') && hasAdminAccess(),
 		}
 		data-theme='light'
+		style=customHeaderLogoStyle
 	)
 		if settings.recaptcha && settings.recaptcha.siteKeyV3
 			script(

--- a/services/web/app/views/layout/navbar-marketing.pug
+++ b/services/web/app/views/layout/navbar-marketing.pug
@@ -11,7 +11,7 @@ nav.navbar.navbar-default.navbar-main.navbar-expand-lg(
 		.navbar-header
 			a.navbar-brand(href='/' aria-label=settings.appName)
 				if settings.nav.custom_logo
-					.navbar-logo(style=`background-image:url("${settings.nav.custom_logo}")`)
+					.navbar-logo.navbar-logo-custom
 				if nav.title
 					.navbar-title #{nav.title}
 				if !nav.title && !settings.nav.custom_logo

--- a/services/web/frontend/js/shared/components/navbar/header-logo-or-title.tsx
+++ b/services/web/frontend/js/shared/components/navbar/header-logo-or-title.tsx
@@ -9,13 +9,16 @@ export default function HeaderLogoOrTitle({
   overleafLogo?: string
 }) {
   const { appName } = getMeta('ol-ExposedSettings')
-  const logoUrl = customLogo ?? overleafLogo
   return (
     <a href="/" aria-label={appName} className="navbar-brand">
       {(customLogo || !title) && (
         <div
-          className="navbar-logo"
-          style={logoUrl ? { backgroundImage: `url("${logoUrl}")` } : {}}
+          className={`navbar-logo${customLogo ? ' navbar-logo-custom' : ''}`}
+          style={
+            !customLogo && overleafLogo
+              ? { backgroundImage: `url("${overleafLogo}")` }
+              : undefined
+          }
         />
       )}
       {title && (

--- a/services/web/frontend/stylesheets/components/navbar.scss
+++ b/services/web/frontend/stylesheets/components/navbar.scss
@@ -50,6 +50,13 @@
       padding: 0;
       background: var(--navbar-brand-image-url) no-repeat left center;
       background-size: contain;
+
+      &.navbar-logo-custom {
+        background-image: var(
+          --navbar-custom-logo-light-url,
+          var(--navbar-brand-image-url)
+        );
+      }
     }
 
     .navbar-title {
@@ -312,6 +319,13 @@
 }
 
 @include theme('default') {
+  .navbar-default .navbar-brand .navbar-logo.navbar-logo-custom {
+    background-image: var(
+      --navbar-custom-logo-dark-url,
+      var(--navbar-custom-logo-light-url, var(--navbar-brand-image-url))
+    );
+  }
+
   #project-list-root,
   #library-root {
     .website-redesign-navbar,


### PR DESCRIPTION
## Summary

Add support for separate custom header logos for light and dark themes while preserving the existing header logo behavior.

## Changes

- Add support for:
  - `OVERLEAF_HEADER_IMAGE_URL_LIGHT`
  - `OVERLEAF_HEADER_IMAGE_URL_DARK`
- Preserve compatibility with the existing `OVERLEAF_HEADER_IMAGE_URL`.
- Automatically switch the header logo when the website theme changes.


## Backward compatibility

Existing installations using only `OVERLEAF_HEADER_IMAGE_URL` retain their current behavior. No changes are required to existing configurations.