### PR TITLE
fix(git-bridge): return ObjectId from getUserId, so git access checks pass

### DIFF
--- a/services/web/modules/git-bridge/app/src/GitBridgePATManager.mjs
+++ b/services/web/modules/git-bridge/app/src/GitBridgePATManager.mjs
@@ -118,7 +118,7 @@ const GitBridgePATManager = {
       logger.error({ err }, 'Failed to update lastUsedAt')
     )
 
-    return objToken.user_id
+    return new ObjectId(objToken.user_id)
   },
 }
 


### PR DESCRIPTION
### Problem

With the Git bridge enabled, **every** git operation fails with `403`, even for
the project owner:

```
$ git clone https://git@overleaf.example.com/git/<project-id>
fatal: unable to access '...': The requested URL returned error: 403
```

Authentication itself succeeds — the token is found and `lastUsedAt` is updated
in `oauthAccessTokens` — so the failure happens later, in the authorization
check.

### Cause

`GitBridgePATManager.getUserId()` returns `user_id` as a **string**:

```js
// modules/git-bridge/app/src/GitBridgePATManager.mjs:121
return objToken.user_id
```

`GitBridgeAuthMiddleware` passes that value straight to
`AuthorizationManager.promises.canUserReadProject()`, which compares it against
`project.owner_ref` — an `ObjectId`. The comparison fails and the middleware
returns `403`.

The same function already handles the conversion correctly a few lines above,
when it checks that the user still exists:

```js
const user = await db.users.findOne(
  { _id: new ObjectId(objToken.user_id) },   // ← converted here
  { projection: { _id: 1 } }
)
...
return objToken.user_id                       // ← but returned raw
```

`ObjectId` is already imported in this file, so no new import is needed.

### Fix

```diff
-    return objToken.user_id
+    return new ObjectId(objToken.user_id)
```

### Verification

Tested on a self-hosted deployment (Extended CE, git-bridge as a separate
container). Before the change, `/api/v0/docs/:project_id` with a valid
`Authorization: Bearer <token>` returns `403`; after it returns `200`, and both
`git clone` and `git push` complete normally.

Affects `ext-ce`, `ext-ce-v6.1` and `ext-ce-v6.2` — all carry the same line.
